### PR TITLE
Small update to conf file to warn about ZMK Studio usage

### DIFF
--- a/config/lily58.conf
+++ b/config/lily58.conf
@@ -8,7 +8,7 @@ CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
 CONFIG_ZMK_KSCAN_DEBOUNCE_PRESS_MS=1
 CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS=10
 
-# Enable ZMK Studio for Realtime Keymap Updates
+# Enable ZMK Studio for Realtime Keymap Updates (you should disable this when flashing directly)
 CONFIG_ZMK_STUDIO=y
 CONFIG_ZMK_STUDIO_LOCKING=n
 


### PR DESCRIPTION
I spent an inordinate amount of time debugging why my flashed keymap was having a ton of undefined behavior. Turns out, leaving ZMK studio on while flashing directly was the culprit. I have added a small warning to those that come after me that may run into the same issue. 

Cheers, love the keyboard